### PR TITLE
Add support for Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules
+.git
+.gitignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM node:12
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+RUN npm install -g @angular/cli@7.3.7
+RUN npm install
+
+COPY . /app
+
+# Build app
+RUN ng build --prod --base-href /app/
+
+# Start app
+CMD ng serve --host 0.0.0.0

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Tidy Mail puts privacy first and therefore all code that accesses a users email 
 ## Build
 - run `ng build --prod --base-href /app/`
 
+## Docker
+To use the application with Docker, simply execute the following commands.
+
+- run `npm run docker:build`
+- run `npm run docker:start`
+
 ## License
 
 Code released under [the AGPL license](https://github.com/Datum/tidymail-app/blob/master/LICENSE).

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",
-    "e2e": "ng e2e"
+    "e2e": "ng e2e",
+    "docker:start": "docker run -p 4200:4200 --rm tidymail-app:latest",
+    "docker:build": "docker build -t tidymail-app:latest ."
   },
   "author": "Datum Network GmbH",
   "license": "AGPL-3.0-or-later",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "lib": [
       "es2018",
       "dom"
-    ]
+    ],
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Adds support for running the application as a Docker container.
Provided you have Docker installed, you can start a new container using the image with the following commands.

**Build the Docker image**
`npm run docker:build`

**Start a new container using the image**
`npm run docker:start`

resolves #43